### PR TITLE
use boostrap gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Dradis Framework #.## (Month, 2020) ##
+
+*   Use Bootstrap gem vs vendored assets.
+
 ## Dradis Framework 3.19 (September, 2020) ##
 
 *   No changes.

--- a/app/assets/stylesheets/dradis/plugins/calculators/dread/manifests/application.css.scss
+++ b/app/assets/stylesheets/dradis/plugins/calculators/dread/manifests/application.css.scss
@@ -1,2 +1,1 @@
-@import 'bootstrap';
-@import 'bootstrap-responsive';
+@import '_bootstrap';

--- a/app/views/dradis/plugins/calculators/dread/_addons_menu.html.erb
+++ b/app/views/dradis/plugins/calculators/dread/_addons_menu.html.erb
@@ -1,0 +1,1 @@
+<%= link_to 'Risk Calculators - DREAD', dread_calculator.dread_path, class: 'dropdown-item', data: { turbolinks: false } %>

--- a/app/views/dradis/plugins/calculators/dread/_addons_menu.html.erb
+++ b/app/views/dradis/plugins/calculators/dread/_addons_menu.html.erb
@@ -1,1 +1,0 @@
-<li><%= link_to 'Risk Calculators - DREAD', dread_calculator.dread_path %></li>

--- a/app/views/dradis/plugins/calculators/dread/_addons_menu_bs4.html.erb
+++ b/app/views/dradis/plugins/calculators/dread/_addons_menu_bs4.html.erb
@@ -1,1 +1,0 @@
-<%= link_to 'Risk Calculators - DREAD', dread_calculator.dread_path, class: 'dropdown-item' %>


### PR DESCRIPTION
### Summary

This PR updates the asset manifest to use the Bootstrap gem bundled with the main app.

### Check List
- [x] Added a CHANGELOG entry
