### PR TITLE
Update Dradis links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v4.12.0 (XXXX 2024)
+  - Update Dradis links in README
+
 v4.11.0 (January 2024)
   - No changes
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ This simple addon adds a new page under `/calculators/dread` for you to perform 
 
 DREAD stands for (D)amage, (R)eproducibility, (E)xploitability, (A)ffected users, (D)iscoverability and is a common risk assessment model [introduced by Microsoft](http://blogs.msdn.com/b/david_leblanc/archive/2007/08/13/dreadful.aspx).
 
-The add-on requires [Dradis CE](https://dradisframework.com/) > 3.0, or [Dradis Pro](https://dradisframework.com/pro/).
-
+The add-on requires [Dradis CE](https://dradis.com/ce/) > 3.0, or [Dradis Pro](https://dradis.com/).
 
 ## Install
 


### PR DESCRIPTION
### Summary

Update README so that Dradis CE and Dradis links are now using https://dradis.com/ce/ and https://dradis.com/ respectively.

### Copyright assignment

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
- [ ] Added specs
