### PR TITLE
Remove configuration table check as it is now done in dradis-plugins

### DIFF
--- a/lib/dradis/plugins/calculators/dread/engine.rb
+++ b/lib/dradis/plugins/calculators/dread/engine.rb
@@ -24,17 +24,15 @@ module Dradis::Plugins::Calculators::DREAD
       # By default, this engine is loaded into the main app. So, upon app
       # initialization, we first check if the DB is loaded and the Configuration
       # table has been created, before checking if the engine is enabled
-      Rails.application.reloader.to_prepare do
-        if (ActiveRecord::Base.connection rescue false) && ::Configuration.table_exists?
-          Rails.application.routes.append do
-            # Enabling/disabling integrations calls Rails.application.reload_routes! we need the enable
-            # check inside the block to ensure the routes can be re-enabled without a server restart
-            if Engine.enabled?
-              mount Engine => '/', as: :dread_calculator
-            end
+      # Rails.application.reloader.to_prepare do
+        Rails.application.routes.append do
+          # Enabling/disabling integrations calls Rails.application.reload_routes! we need the enable
+          # check inside the block to ensure the routes can be re-enabled without a server restart
+          if Engine.enabled?
+            mount Engine => '/', as: :dread_calculator
           end
         end
-      end
+      # end
     end
   end
 end

--- a/lib/dradis/plugins/calculators/dread/engine.rb
+++ b/lib/dradis/plugins/calculators/dread/engine.rb
@@ -21,10 +21,6 @@ module Dradis::Plugins::Calculators::DREAD
     end
 
     initializer 'calculator_dread.mount_engine' do
-      # By default, this engine is loaded into the main app. So, upon app
-      # initialization, we first check if the DB is loaded and the Configuration
-      # table has been created, before checking if the engine is enabled
-      # Rails.application.reloader.to_prepare do
         Rails.application.routes.append do
           # Enabling/disabling integrations calls Rails.application.reload_routes! we need the enable
           # check inside the block to ensure the routes can be re-enabled without a server restart


### PR DESCRIPTION
### Summary

Previously, we needed to check `if (ActiveRecord::Base.connection rescue false) && ::Configuration.table_exists?` before checking `engine.enabled?`. We are now doing this check in [dradis-plugins](https://github.com/dradis/dradis-plugins/pull/101) so we can remove it here

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

~- [ ] Added a CHANGELOG entry~
~- [ ] Added specs~
